### PR TITLE
fix header string check

### DIFF
--- a/gen-site.sh
+++ b/gen-site.sh
@@ -113,10 +113,9 @@ main() {
   init
   sync_content
   while IFS= read -r -d $'\0' file; do
-    # short circult early if already 
-    [[ $(head -n 1 "$file") == "$HEADER_STRING" ]] && continue
     sub_links "$file"
-    insert_header "$file"
+    # insert header if not found
+    [[ $(head -n 1 "$file") != "$HEADER_STRING" ]] && insert_header "$file"
     # if its a README, it must be renamed to _index
     [[ $(basename "${file,,}") == 'readme.md' ]] && rename_file "$file"
   done < <(find_md_files)


### PR DESCRIPTION
This resolves the issue where some files were not having their links corrected after the header template change from `+++` to `---` (toml to yaml).

Now the `sub_links()` function will be called on **ALL** markdown files no matter their header. 

/assign castrojo