### PR TITLE
Remove design proposals

### DIFF
--- a/exclude.list
+++ b/exclude.list
@@ -15,3 +15,4 @@ sigs.yaml
 /hack
 /generator
 /icons
+/contributors/design-proposals


### PR DESCRIPTION
This removes the design proposals from the site, there's tons of broken links there and it would be a ton of work to fix them. So we're just going to not show them for now and concentrate on KEPs and other content. 