### PR TITLE
Remove event notes but allow rest of events directory

### DIFF
--- a/exclude.list
+++ b/exclude.list
@@ -16,5 +16,7 @@ sigs.yaml
 /generator
 /icons
 /archive
-/events
+/events/2016
+/events/2017
+/events/2018
 /contributors/design-proposals


### PR DESCRIPTION
We want the community meeting, elections, and office hours indexed, but don't really want the contrib summit notes and a bunch of other stuff that doesn't render right. 