### PR TITLE
remove unnecessary title at top of page body

### DIFF
--- a/layouts/partials/original/body-beforecontent.html
+++ b/layouts/partials/original/body-beforecontent.html
@@ -126,9 +126,6 @@
   </div>
 {{end}}
 <div id="body-inner">
-  {{if not .IsHome}}
-    <h1>{{.Title}}</h1>
-  {{end}}
 
 {{define "breadcrumb"}}
 {{ if .page.Parent}}


### PR DESCRIPTION
This removes the unnecessary additional title that was found in many of the pages.

/assign @castrojo 