### PR TITLE
Netlify Build Error fix

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,6 @@
 [build]
 publish = "build/public"
-command = "./gen-site.sh"
+command = "python -c 'import os,sys,fcntl; flags = fcntl.fcntl(sys.stdout, fcntl.F_GETFL); fcntl.fcntl(sys.stdout, fcntl.F_SETFL, flags&~os.O_NONBLOCK);' && ./gen-site.sh"
 
 [build.environment]
 HUGO_VERSION = "0.49"
@@ -10,10 +10,10 @@ HUGO_BUILD = "true"
 HUGO_ENV = "production"
 
 [context.deploy-preview]
-command = "./gen-site.sh -b $DEPLOY_PRIME_URL"
+command = "python -c 'import os,sys,fcntl; flags = fcntl.fcntl(sys.stdout, fcntl.F_GETFL); fcntl.fcntl(sys.stdout, fcntl.F_SETFL, flags&~os.O_NONBLOCK);' && ./gen-site.sh -b $DEPLOY_PRIME_URL"
 
 [context.branch-deploy]
-command = "./gen-site.sh -b $DEPLOY_PRIME_URL"
+command = "python -c 'import os,sys,fcntl; flags = fcntl.fcntl(sys.stdout, fcntl.F_GETFL); fcntl.fcntl(sys.stdout, fcntl.F_SETFL, flags&~os.O_NONBLOCK);' && ./gen-site.sh -b $DEPLOY_PRIME_URL"
 
 [context.branch-deploy.environment]
-command = "./gen-site.sh -b $DEPLOY_PRIME_URL"
+command = "python -c 'import os,sys,fcntl; flags = fcntl.fcntl(sys.stdout, fcntl.F_GETFL); fcntl.fcntl(sys.stdout, fcntl.F_SETFL, flags&~os.O_NONBLOCK);' && ./gen-site.sh -b $DEPLOY_PRIME_URL"


### PR DESCRIPTION
This resolves the inconsistent build errors encountered in the Netlify builds. 

The errors would happen randomly and at different points usually with a simple exit 1, or `echo: write error: Resource temporarily unavailable`. Netlify has their stdout configured to be non-blocking similar to travis. This unfortunately can cause problems  for shell scripts which do not handle `EAGAIN` situations well. The solution is to enable blocking IO for the duration of the build.

/hold