### PR TITLE
Add AnchorJS support

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -1,3 +1,13 @@
+function anchorTags() {
+  const selectors = '.doc-content h1, .doc-content h2, .doc-content h3, .doc-content h4';
+
+  anchors.options = {
+    icon: '#'
+  }
+
+  anchors.add(selectors);
+}
+
 function navbarToggle() {
   $('.navbar-burger').click(function() {
     $('.navbar-burger').toggleClass('is-active');
@@ -7,4 +17,5 @@ function navbarToggle() {
 
 $(function() {
   navbarToggle();
+  anchorTags();
 });

--- a/assets/sass/main.sass
+++ b/assets/sass/main.sass
@@ -14,3 +14,7 @@
       h1, h2, h3, h4, h5, h6
         text-transform: uppercase
         font-weight: 300
+
+    .doc-content
+      .anchorjs-link:after
+        color: $primary

--- a/content/other-page.md
+++ b/content/other-page.md
@@ -5,3 +5,9 @@ weight: 2
 ---
 
 Here's some more information.
+
+# Header 1
+
+## Header 2
+
+### Header 3

--- a/layouts/partials/article.html
+++ b/layouts/partials/article.html
@@ -1,5 +1,5 @@
 <section class="section">
-  <div class="content">
+  <div class="doc-content content">
     {{ .Content }}
   </div>
 </section>

--- a/layouts/partials/javascript.html
+++ b/layouts/partials/javascript.html
@@ -1,6 +1,7 @@
 {{ $calendar   := .Params.calendar }}
 {{ $app        := resources.Get "js/app.js" | fingerprint }}
 <script src="https://code.jquery.com/jquery-3.4.0.min.js" integrity="sha256-BJeo0qm959uMBGb65z40ejJYGSgR7REI4+CW1fNKwOg=" crossorigin="anonymous"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/anchor-js/4.2.0/anchor.min.js" integrity="sha256-m1eTvwEHwmsw4+XKF7BshClVJEPwTVycveNl0CS0Mkk=" crossorigin="anonymous"></script>
 {{ if $calendar }}
 {{ $extraJs    := site.Params.fullcalendar.js }}
 {{ range $extraJs }}


### PR DESCRIPTION
This PR adds support for [AnchorJS](https://github.com/bryanbraun/anchorjs) hoverable anchor tags. For an example, see this page:

https://deploy-preview-49--kubernetes-contributor.netlify.com/other-page/

Hover over the headings to see the widget in action.