### PR TITLE
Add smooth scrolling for mobile

### DIFF
--- a/assets/sass/style.sass
+++ b/assets/sass/style.sass
@@ -27,3 +27,7 @@
 @import "main"
 @import "navbar"
 @import "calendar"
+
+html
+  -webkit-overflow-scrolling: touch
+  height: 100%


### PR DESCRIPTION
I forgot that Flexbox has this weird property where it makes mobile scrolling slow and halting by default on some browsers. This PR fixes that.