### PR TITLE
Add custom youtube shortcode

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,27 @@ You can then preview the site by running `make docker-server`.
 
 To run the site locally using an installed Hugo executable, run `make server`.
 
+## YouTube embeds
+
+You can embed YouTube videos on pages using the `youtube` shortcode and
+specifying the unique ID of the video. Here's an example:
+
+```bash
+Check out this cool video:
+
+{{< youtube 6cCEmAisx8A >}}
+```
+
+This embed would take up the full width of the surrounding element. You can
+specify a smaller width as a percentage by changing the second argument. This
+embed, for example, would occupy 70% of the width:
+
+```bash
+Check out this cool video:
+
+{{< youtube 6cCEmAisx8A 70 >}}
+```
+
 ## Community, discussion, contribution, and support
 
 This project is managed by [SIG Contributor Experience][sig-contribex] as a

--- a/assets/sass/style.sass
+++ b/assets/sass/style.sass
@@ -32,3 +32,15 @@
 html
   -webkit-overflow-scrolling: touch
   height: 100%
+
+.youtube-embed
+  position: relative
+  padding-bottom: 56.25%
+  height: 0
+  overflow: hidden
+
+  &-iframe
+    position: absolute
+    top: 0
+    left: 0
+    border: 0

--- a/layouts/shortcodes/youtube.html
+++ b/layouts/shortcodes/youtube.html
@@ -1,0 +1,5 @@
+{{ $id    := .Get 0 }}
+{{ $size  := .Get 1 | default 100 }}
+<div class="youtube-embed">
+  <iframe class="youtube-embed-iframe" src="//www.youtube.com/embed/{{ $id }}" style="width: {{ $size }}%; height: {{ $size }}%;" allowfullscreen="" title="YouTube Video" />
+</div>


### PR DESCRIPTION
Addresses issue #51. With this PR, you can specify a width for YouTube embeds. This, for example, would apply a width of 50%:

```
{{< youtube smwQafhNU6E 50 >}}
```

The default width is 100%. The [main page of the deploy preview](https://deploy-preview-55--kubernetes-contributor.netlify.com/) shows an embed with a width of 70%.