### PR TITLE
Add multi-source support for hack/gen-content.sh

### DIFF
--- a/external-sources/community
+++ b/external-sources/community
@@ -1,0 +1,1 @@
+"/contributors/guide","/guide"


### PR DESCRIPTION
The previous iteration of gen-content was limited to the contributor guide. Multi-source support has been added with the addition of `external-sources`. A directory in the root of the repo that contains csv files (no extension) named after their associated kubernetes repo. The csv files contain 2 columns. Column A is the source within the repo and Column B is the destination within the Hugo content directory.

Markdown links are updated to use the new destination location, or if linking to something not copied over they're updated to reference them via generated `https://git.k8s.io/` addresses.

/cc @castrojo 