### PR TITLE
Fix incomplete side menu on smaller display

### DIFF
--- a/assets/sass/page.sass
+++ b/assets/sass/page.sass
@@ -1,4 +1,3 @@
 .page
   display: flex
   flex-direction: row
-  height: 100vh


### PR DESCRIPTION
When the screen is smaller

only part of the side menu is shown

as reported in the issue below

Closes https://github.com/kubernetes-sigs/contributor-site/issues/81

/assign @mrbobbytables 