### PR TITLE
Improvising ReadME and Code of Conduct section

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ To develop site content, you can run the site locally using [Hugo][hugo] in
 two ways:
 
 1. [Inside a Docker container](#using-docker)
-2. [Natively](#natively) (not inside a Docker container)
+2. [Local Installation](#local-installation) (Without using docker container)
 
 When you make changes to the site's content, Hugo will automatically update
 the site and refresh your browser window.
@@ -44,12 +44,17 @@ To ensure you can view the site with externally sourced content, run
 `make docker-gen-content` before previewing the site by with `make docker-server`.
 
 
-### Natively
+### Local Installation
 
-> For instructions on installing and using Hugo, see the [Hugo
-> Documentation][hugo-docs].
+>Install Hugo before setting up the project on your local machine. For more 
+>details on Hugo, See [here][hugo].
 
-To run the site locally using an installed Hugo executable, run `make server`.
+- Fork & Clone the repository on your local machine.
+- Verify `Hugo` installation by using :
+```sh
+hugo --version
+```
+- Run the site using `hugo server`
 
 ## YouTube embeds
 

--- a/config.toml
+++ b/config.toml
@@ -23,7 +23,3 @@ sizes = [300,400,600,700]
 [[menu.sidebar]]
 name = "Role Board"
 url = "https://discuss.kubernetes.io/c/contributors/role-board"
-[[menu.sidebar]]
-name = "Code of Conduct"
-url = "https://github.com/kubernetes/community/blob/master/code-of-conduct.md"
-

--- a/content/code-of-conduct.md
+++ b/content/code-of-conduct.md
@@ -1,0 +1,46 @@
+---
+title: Code of Conduct
+description: Kubernetes Code of Conduct
+---
+
+As contributors and maintainers of this project, and in the interest of fostering
+an open and welcoming community, we pledge to respect all people who contribute
+through reporting issues, posting feature requests, updating documentation,
+submitting pull requests or patches, and other activities.
+
+We are committed to making participation in this project a harassment-free experience for
+everyone, regardless of level of experience, gender, gender identity and expression,
+sexual orientation, disability, personal appearance, body size, race, ethnicity, age,
+religion, or nationality.
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery
+* Personal attacks
+* Trolling or insulting/derogatory comments
+* Public or private harassment
+* Publishing others' private information, such as physical or electronic addresses,
+ without explicit permission
+* Other unethical or unprofessional conduct.
+
+Project maintainers have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are not
+aligned to this Code of Conduct. By adopting this Code of Conduct, project maintainers
+commit themselves to fairly and consistently applying these principles to every aspect
+of managing this project. Project maintainers who do not follow or enforce the Code of
+Conduct may be permanently removed from the project team.
+
+This code of conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community.
+
+Instances of abusive, harassing, or otherwise unacceptable behavior in Kubernetes may be reported by contacting the [Kubernetes Code of Conduct Committee](https://git.k8s.io/community/committee-code-of-conduct) via <conduct@kubernetes.io>. For other projects, please contact a CNCF project maintainer or our mediator, Mishi Choudhary <mishi@linux.com>.
+
+This Code of Conduct is adapted from the Contributor Covenant
+(http://contributor-covenant.org), version 1.2.0, available at
+http://contributor-covenant.org/version/1/2/0/
+
+### CNCF Events Code of Conduct
+
+CNCF events are governed by the Linux Foundation [Code of Conduct](https://events.linuxfoundation.org/code-of-conduct/) available on the event page. This is designed to be compatible with the above policy and also includes more details on responding to incidents.
+
+### To view this content in different languages, visit [here](https://github.com/cncf/foundation/blob/master/code-of-conduct.md).


### PR DESCRIPTION
Fixes #71 
- This PR also revamps the READme Section for setting up the project locally without a docker container.