### PR TITLE
Add release schedule link.

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -40,7 +40,13 @@ name = "Roboto"
 sizes = [300,400,600,700]
 
 [menu]
+
+[[menu.sidebar]]
+name = "Release Schedule (1.18)"
+url = "https://git.k8s.io/sig-release/releases/release-1.18#timeline"
+weight = 98
+
 [[menu.sidebar]]
 name = "Role Board"
 url = "https://discuss.kubernetes.io/c/contributors/role-board"
-
+weight = 99


### PR DESCRIPTION
Fixes #2 

While not a release dashboard, we can provide a link to the current timeline doc and update it each cycle with the new one.

/assign @castrojo 