### PR TITLE
Import release timeline doc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ resources/
 
 # Files synced to the root of the content directory should be added to the ignore list.
 content/code-of-conduct.md
+content/release.md
 
 # Temp directory for processing content
 _tmp/

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@ DOCKER			?= docker
 DOCKER_RUN		:= $(DOCKER) run --rm -it -v $(CURDIR):/src
 HUGO_VERSION		:= $(shell grep ^HUGO_VERSION netlify.toml | tail -n 1 | cut -d '=' -f 2 | tr -d " \"\n")
 DOCKER_IMAGE		:= k8s-contrib-site-hugo
+REPO_ROOT	:=${CURDIR}
 
 # Fast NONBlOCKING IO to stdout caused by the hack/gen-content.sh script can
 # cause Netlify builds to terminate unexpectantly. This forces stdout to block.
@@ -26,7 +27,7 @@ BLOCK_STDOUT_CMD	:= python -c "import os,sys,fcntl; \
 .DEFAULT_GOAL	:= help
 
 .PHONY: targets docker-targets
-targets: help gen-content render serve clean production preview-build
+targets: help gen-content render serve clean clean-all sproduction preview-build
 docker-targets: docker-image docker-gen-content docker-render docker-server
 
 help: ## Show this help text.
@@ -66,6 +67,12 @@ docker-server: ## Run Hugo locally within a Docker container (equiv to server).
 
 clean: ## Cleans build artifacts.
 	rm -rf public/ resources/ _tmp/
+
+clean-all: ## Cleans both build artifacts and files sycned to content directory
+	rm -rf public/ resources/ _tmp/
+	rm -f content/code-of-conduct.md
+	rm -f content/release.md
+	find content/guide -not -name ".gitignore" -not -name "guide" -maxdepth 1 -exec rm -rf {} \;
 
 production-build: ## Builds the production site (this command used only by Netlify).
 	$(BLOCK_STDOUT_CMD)

--- a/config.toml
+++ b/config.toml
@@ -42,11 +42,6 @@ sizes = [300,400,600,700]
 [menu]
 
 [[menu.sidebar]]
-name = "Release Schedule (1.18)"
-url = "https://git.k8s.io/sig-release/releases/release-1.18#timeline"
-weight = 98
-
-[[menu.sidebar]]
 name = "Role Board"
 url = "https://discuss.kubernetes.io/c/contributors/role-board"
 weight = 99

--- a/external-sources/kubernetes/sig-release
+++ b/external-sources/kubernetes/sig-release
@@ -1,0 +1,1 @@
+"/releases/release-1.18/README.md","/release.md"


### PR DESCRIPTION
This both imports the release docs and fixes a bug when importing and renaming a README document when the destination is intended to be renamed.

"Previously the script made a false assumption that source and destination filenames would be the same UNLESS the file was a readme. This caused an issue when importing a singular source readme with a different name once imported."

fixes #2 
/cc @vishakhanihore 