### PR TITLE
Fix svg render bug

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,8 +84,9 @@ production-build: ## Builds the production site (this command used only by Netli
 	hack/gen-content.sh
 	hugo \
 		--verbose \
-		--ignoreCache \
-		--minify
+		--ignoreCache
+
+		# --minify -Add back in when hugo upgrades to minify 2.7.3 or greater
 
 preview-build: ## Builds a deploy preview of the site (this command used only by Netlify).
 	$(BLOCK_STDOUT_CMD)
@@ -96,5 +97,6 @@ preview-build: ## Builds a deploy preview of the site (this command used only by
 		--baseURL $(DEPLOY_PRIME_URL) \
 		--buildDrafts \
 		--buildFuture \
-		--ignoreCache \
-		--minify
+		--ignoreCache
+
+		# --minify -Add back in when hugo upgrades to minify 2.7.3 or greater


### PR DESCRIPTION
There is a bug in hugo and the upstream minify library that causes svgs
to not be rendered correctly. This has been fixed in the upstream
library (https://github.com/tdewolff/minify) as of minify 2.7.3. This
can be reverted or undone once Hugo upgrades to using that version or
better.


/kind bug
ref: https://github.com/kubernetes-sigs/contributor-site/issues/129