### PR TITLE
Add temp baseurl

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,4 +1,4 @@
-baseURL = "/"
+baseURL = "https://kubernetes-contributor.netlify.app/"
 title = "Kubernetes Contributors"
 theme = ["docsy"]
 enableRobotsTXT = true


### PR DESCRIPTION
This will resolve the issue of the calendar not being displayed until the domain can be transferred over and configured