### PR TITLE
Remove last modified footer

### DIFF
--- a/layouts/_default/content.html
+++ b/layouts/_default/content.html
@@ -1,19 +1,16 @@
-{{ define "main" }}
 <div class="td-content">
 	<h1>{{ .Title }}</h1>
-        {{ with .Params.description }}<div class="lead">{{ . | markdownify }}</div>{{ end }}
+    {{ with .Params.description }}<div class="lead">{{ . | markdownify }}</div>{{ end }}
 	{{ if (and (not .Params.hide_readingtime) (.Site.Params.ui.readingtime.enable)) }}
-            {{ partial "reading-time.html" . }}
-        {{ end }}
+        {{ partial "reading-time.html" . }}
+    {{ end }}       
 	{{ .Content }}
-        {{ partial "section-index.html" . }}
 	{{ if (and (not .Params.hide_feedback) (.Site.Params.ui.feedback.enable) (.Site.GoogleAnalytics)) }}
 		{{ partial "feedback.html" .Site.Params.ui.feedback }}
 		<br />
 	{{ end }}
-	{{ if (.Site.DisqusShortname) }}
+	{{ if (.Site.Params.DisqusShortname) }}
 		<br />
 		{{ partial "disqus-comment.html" . }}
 	{{ end }}
 </div>
-{{ end }}

--- a/layouts/docs/list.html
+++ b/layouts/docs/list.html
@@ -15,6 +15,5 @@
 		<br />
 		{{ partial "disqus-comment.html" . }}
 	{{ end }}
-	<div class="text-muted mt-5 pt-3 border-top">{{ partial "page-meta-lastmod.html" . }}</div>
 </div>
 {{ end }}

--- a/layouts/events/list.html
+++ b/layouts/events/list.html
@@ -15,6 +15,5 @@
 		<br />
 		{{ partial "disqus-comment.html" . }}
 	{{ end }}
-	<div class="text-muted mt-5 pt-3 border-top">{{ partial "page-meta-lastmod.html" . }}</div>
 </div>
 {{ end }}

--- a/layouts/resources/list.html
+++ b/layouts/resources/list.html
@@ -15,6 +15,5 @@
 		<br />
 		{{ partial "disqus-comment.html" . }}
 	{{ end }}
-	<div class="text-muted mt-5 pt-3 border-top">{{ partial "page-meta-lastmod.html" . }}</div>
 </div>
 {{ end }}


### PR DESCRIPTION
As most of the content is ingested externally and not tracked in git,
the content last modified footer always displayed "January 1, 0001".

Should content be moved into the contributor site directly, this commit
should be reverted to add the last modified functionality back.