### PR TITLE
Remove scalability section from guide

### DIFF
--- a/external-sources/kubernetes/community
+++ b/external-sources/kubernetes/community
@@ -12,7 +12,6 @@
 "/contributors/guide/owners.md","/docs/guide/owners.md"
 "/contributors/guide/pull-requests.md","/docs/guide/pull-requests.md"
 "/contributors/guide/release-notes.md","/docs/guide/release-notes.md"
-"/contributors/guide/scalability-good-practices.md","/docs/guide/scalability-good-practices.md"
 "/contributors/guide/git_workflow.png","/docs/guide/git_workflow.png"
 "/contributors/guide/contributor-cheatsheet/README.md","/docs/contributor-cheatsheet.md"
 "/events/community-meeting.md","/events/community-meeting.md"


### PR DESCRIPTION
The scalability best practices portion of the guide is planned to be moved to the developer guide.