### PR TITLE
 Allow specifying alternative tool for containerized local testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,7 @@ docker-server:
 container-serve: ## Run Hugo locally within a container, available at http://localhost:1313/
 	git submodule update --init --recursive --depth 1
 	$(CONTAINER_RUN) -p 1313:1313 \
-		--mount type=tmpfs,destination=/src/resources,tmpfs-mode=0777 \
+		--mount type=tmpfs,destination=/tmp,tmpfs-mode=01777 \
 		$(CONTAINER_IMAGE) \
 	hugo server \
 		--verbose \
@@ -85,7 +85,9 @@ container-serve: ## Run Hugo locally within a container, available at http://loc
 		--buildDrafts \
 		--buildFuture \
 		--disableFastRender \
-		--ignoreCache
+		--ignoreCache \
+		--destination /tmp/hugo \
+		--cleanDestinationDir
 
 clean: ## Cleans build artifacts.
 	rm -rf public/ resources/ _tmp/

--- a/Makefile
+++ b/Makefile
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-DOCKER			?= docker
-DOCKER_RUN		:= $(DOCKER) run --rm -it -v $(CURDIR):/src
+CONTAINER_ENGINE	?= docker
+CONTAINER_RUN		:= $(CONTAINER_ENGINE) run --rm -it -v $(CURDIR):/src
 HUGO_VERSION		:= $(shell grep ^HUGO_VERSION netlify.toml | tail -n 1 | cut -d '=' -f 2 | tr -d " \"\n")
-DOCKER_IMAGE		:= k8s-contrib-site-hugo
+CONTAINER_IMAGE		:= k8s-contrib-site-hugo
 REPO_ROOT	:=${CURDIR}
 
 # Fast NONBlOCKING IO to stdout caused by the hack/gen-content.sh script can
@@ -26,9 +26,9 @@ BLOCK_STDOUT_CMD	:= python -c "import os,sys,fcntl; \
 
 .DEFAULT_GOAL	:= help
 
-.PHONY: targets docker-targets
+.PHONY: targets container-targets
 targets: help gen-content render serve clean clean-all sproduction preview-build
-docker-targets: docker-image docker-gen-content docker-render docker-server
+container-targets: container-image container-gen-content container-render container-server
 
 help: ## Show this help text.
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'
@@ -49,19 +49,34 @@ server: ## Run Hugo locally (if Hugo "extended" is installed locally)
 		--disableFastRender \
 		--ignoreCache
 
-docker-image: ## Build container image for use with docker-* targets.
-	$(DOCKER) build . -t $(DOCKER_IMAGE) --build-arg HUGO_VERSION=$(HUGO_VERSION)
+docker-image: container-image
+	@echo -e "**** The use of docker-image is deprecated. Use container-image instead. ****" 1>&2
 
-docker-gen-content: ## Generates content from external sources within a Docker container (equiv to gen-content).
-	$(DOCKER_RUN) $(DOCKER_IMAGE) hack/gen-content.sh
+container-image: ## Build container image for use with container-* targets.
+	$(CONTAINER_ENGINE) build . -t $(CONTAINER_IMAGE) --build-arg HUGO_VERSION=$(HUGO_VERSION)
 
-docker-render: ## Build the site using Hugo within a Docker container (equiv to render).
-	$(DOCKER_RUN) $(DOCKER_IMAGE) git submodule update --init --recursive --depth 1
-	$(DOCKER_RUN) $(DOCKER_IMAGE) hugo --verbose --ignoreCache --minify
+docker-gen-content:
+	@echo -e "**** The use of docker-gen-content is deprecated. Use container-gen-content instead. ****" 1>&2
+	$(MAKE) container-gen-content
 
-docker-server: ## Run Hugo locally within a Docker container (equiv to server).
-	$(DOCKER_RUN) $(DOCKER_IMAGE) git submodule update --init --recursive --depth 1
-	$(DOCKER_RUN) -p 1313:1313 $(DOCKER_IMAGE) hugo server \
+container-gen-content: ## Generates content from external sources within a container (equiv to gen-content).
+	$(CONTAINER_RUN) $(CONTAINER_IMAGE) hack/gen-content.sh
+
+docker-render:
+	@echo -e "**** The use of docker-render is deprecated. Use container-render instead. ****" 1>&2
+	$(MAKE) container-render
+
+container-render: ## Build the site using Hugo within a container (equiv to render).
+	$(CONTAINER_RUN) $(CONTAINER_IMAGE) git submodule update --init --recursive --depth 1
+	$(CONTAINER_RUN) $(CONTAINER_IMAGE) hugo --verbose --ignoreCache --minify
+
+docker-server:
+	@echo -e "**** The use of docker-render is deprecated. Use container-serve instead. ****" 1>&2
+	$(MAKE) container-serve
+
+container-serve: ## Run Hugo locally within a container, available at http://localhost:1313/
+	$(CONTAINER_RUN) $(CONTAINER_IMAGE) git submodule update --init --recursive --depth 1
+	$(CONTAINER_RUN) -p 1313:1313 $(CONTAINER_IMAGE) hugo server \
 		--verbose \
 		--bind 0.0.0.0 \
 		--buildDrafts \

--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ docker-render:
 	$(MAKE) container-render
 
 container-render: ## Build the site using Hugo within a container (equiv to render).
-	$(CONTAINER_RUN) $(CONTAINER_IMAGE) git submodule update --init --recursive --depth 1
+	git submodule update --init --recursive --depth 1
 	$(CONTAINER_RUN) $(CONTAINER_IMAGE) hugo --verbose --ignoreCache --minify
 
 docker-server:
@@ -75,8 +75,11 @@ docker-server:
 	$(MAKE) container-serve
 
 container-serve: ## Run Hugo locally within a container, available at http://localhost:1313/
-	$(CONTAINER_RUN) $(CONTAINER_IMAGE) git submodule update --init --recursive --depth 1
-	$(CONTAINER_RUN) -p 1313:1313 $(CONTAINER_IMAGE) hugo server \
+	git submodule update --init --recursive --depth 1
+	$(CONTAINER_RUN) -p 1313:1313 \
+		--mount type=tmpfs,destination=/src/resources,tmpfs-mode=0777 \
+		$(CONTAINER_IMAGE) \
+	hugo server \
 		--verbose \
 		--bind 0.0.0.0 \
 		--buildDrafts \

--- a/README.md
+++ b/README.md
@@ -40,11 +40,12 @@ the site and refresh your browser window.
 ### Using Docker
 
 The easiest and most cross-system-compatible way to run the Contributor
-Site is to use [Docker][docker]. To begin, create the docker image to be used 
-with generating the site by executing `make docker-image`.
+Site is to use [Docker][docker]. To begin, create the docker image to be used
+with generating the site by executing `make container-image`.
 
 To ensure you can view the site with externally sourced content, run
-`make docker-gen-content` before previewing the site by with `make docker-server`.
+`make container-gen-content` before previewing the site by with
+`make container-serve`.
 
 
 ### Natively

--- a/config.toml
+++ b/config.toml
@@ -33,6 +33,24 @@ anchor = "smart"
 [services.googleAnalytics]
  id = "UA-98841695-5"
 
+# Hugo internal cacheing
+[caches]
+ [caches.assets]
+  dir = ":cacheDir/_gen"
+  maxAge = -1
+ [caches.getcsv]
+  dir = ":cacheDir/:project"
+  maxAge = "60s"
+ [caches.getjson]
+  dir = ":cacheDir/:project"
+  maxAge = "60s"
+ [caches.images]
+  dir = ":cacheDir/_images"
+  maxAge = -1
+ [caches.modules]
+  dir = ":cacheDir/modules"
+  maxAge = -1
+
 # Language configuration
 
 [languages]


### PR DESCRIPTION
Add support for local previewing with tools, such as [Podman](https://podman.io/), that match Docker's command line conventions.

This PR retains existing Makefile targets such as `docker-render` and `docker-server`, keeping these as deprecated aliases for `container-render` and `container-serve`. The approach is deliberately similar to https://github.com/kubernetes/website/pull/21249.

After this pull request is merged you'll be able to run:
```bash
DOCKER=podman make docker-image # other container tools are available 😉
DOCKER=podman make docker-server
```
and spin up the website locally for testing, without using Docker or needing to have Docker installed.