### PR TITLE
Add Google Custom Search

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -99,7 +99,7 @@ version = "0.0"
 # github_subdir = ""
 
 # Google Custom Search Engine ID. Remove or comment out to disable search.
-# gcs_engine_id = "011737558837375720776:fsdu1nryfng"
+gcs_engine_id = "8ad0f1b8442fece81"
 
 # Enable Algolia DocSearch
 algolia_docsearch = false

--- a/content/en/search.md
+++ b/content/en/search.md
@@ -1,0 +1,4 @@
+---
+title: Search Results
+layout: search
+---


### PR DESCRIPTION
This uses Google custom search for the Docsy search engine. Code was generated with contributors@kubernetes.io account for centralized maintenance.