### PR TITLE
Restore website minification via hugo minify

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -106,8 +106,7 @@ production-build: ## Builds the production site (this command used only by Netli
 		--verbose \
 		--buildFuture \
 		--ignoreCache \
-
-		# --minify -Add back in when hugo upgrades to minify 2.7.3 or greater
+		--minify
 
 preview-build: ## Builds a deploy preview of the site (this command used only by Netlify).
 	$(BLOCK_STDOUT_CMD)
@@ -118,6 +117,5 @@ preview-build: ## Builds a deploy preview of the site (this command used only by
 		--baseURL $(DEPLOY_PRIME_URL) \
 		--buildDrafts \
 		--buildFuture \
-		--ignoreCache
-
-		# --minify -Add back in when hugo upgrades to minify 2.7.3 or greater
+		--ignoreCache \
+		--minify

--- a/layouts/partials/navbar.html
+++ b/layouts/partials/navbar.html
@@ -1,0 +1,37 @@
+{{/* This file is a 1:1 copy of the one in docsy but without
+	minification of the SVG logo.
+	Remove this notice if the condition above changes.
+	Remove this file if we get our hands on an hugo that has tdewolff/minify >= 2.7.3*/}}
+{{ $cover := .HasShortcode "blocks/cover" }}
+<nav class="js-navbar-scroll navbar navbar-expand navbar-dark {{ if $cover}} td-navbar-cover {{ end }}flex-column flex-md-row td-navbar">
+        <a class="navbar-brand" href="{{ .Site.Home.RelPermalink }}">
+		<span class="navbar-logo">{{ if .Site.Params.ui.navbar_logo }}{{ with resources.Get "icons/logo.svg" }}{{ .Content | safeHTML }}{{ end }}{{ end }}</span><span class="text-uppercase font-weight-bold">{{ .Site.Title }}</span>
+	</a>
+	<div class="td-navbar-nav-scroll ml-md-auto" id="main_navbar">
+		<ul class="navbar-nav mt-2 mt-lg-0">
+			{{ $p := . }}
+			{{ range .Site.Menus.main }}
+			<li class="nav-item mr-4 mb-2 mb-lg-0">
+				{{ $active := or ($p.IsMenuCurrent "main" .) ($p.HasMenuCurrent "main" .) }}
+				{{ with .Page }}
+				{{ $active = or $active ( $.IsDescendant .)  }}
+				{{ end }}
+				{{ $url := urls.Parse .URL }}
+				{{ $baseurl := urls.Parse $.Site.Params.Baseurl }}
+				<a class="nav-link{{if $active }} active{{end}}" href="{{ with .Page }}{{ .RelPermalink }}{{ else }}{{ .URL | relLangURL }}{{ end }}" {{ if ne $url.Host $baseurl.Host }}target="_blank" {{ end }}><span{{if $active }} class="active"{{end}}>{{ .Name }}</span></a>
+			</li>
+			{{ end }}
+			{{ if  .Site.Params.versions }}
+			<li class="nav-item dropdown d-none d-lg-block">
+				{{ partial "navbar-version-selector.html" . }}
+			</li>
+			{{ end }}
+			{{ if  (gt (len .Site.Home.Translations) 0) }}
+			<li class="nav-item dropdown d-none d-lg-block">
+				{{ partial "navbar-lang-selector.html" . }}
+			</li>
+			{{ end }}
+		</ul>
+	</div>
+	<div class="navbar-nav d-none d-lg-block">{{ partial "search-input.html" . }}</div>
+</nav>


### PR DESCRIPTION
Hi 🤗 !!

It was disabled in #131 because hugo is not using 1,
however, the hugo project has been trying to update this but it always
introduces regressions and they are having regressions with the JS
minifier.

- https://github.com/gohugoio/hugo/pull/7701
- https://github.com/gohugoio/hugo/issues/7792


I felt like it was a good idea to restore the wide minification and only disable the svg one instead of disabling it completely.

I think this could also be contributed to docsy directly but I thought that doing it here would've been equally good since it's a temporary workaround. 

Once hugo has `tdewolff/minify >= 2.7.3` we can just remove the `navbar.html` partial, I wrote a notice in the file about that too.



Signed-off-by: Lorenzo Fontana <lo@linux.com>