### PR TITLE
fix few minor typos

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,10 +71,10 @@ container-render: ## Build the site using Hugo within a container (equiv to rend
 	$(CONTAINER_RUN) $(CONTAINER_IMAGE) hugo --verbose --ignoreCache --minify
 
 docker-server:
-	@echo -e "**** The use of docker-render is deprecated. Use container-serve instead. ****" 1>&2
-	$(MAKE) container-serve
+	@echo -e "**** The use of docker-server is deprecated. Use container-server instead. ****" 1>&2
+	$(MAKE) container-server
 
-container-serve: ## Run Hugo locally within a container, available at http://localhost:1313/
+container-server: ## Run Hugo locally within a container, available at http://localhost:1313/
 	git submodule update --init --recursive --depth 1
 	$(CONTAINER_RUN) -p 1313:1313 \
 		--mount type=tmpfs,destination=/tmp,tmpfs-mode=01777 \


### PR DESCRIPTION
while deprecating docker-server with container-serve (or container-server), there was some inconsistency.  

e.g. in container-targets, it refers to container-server, while other places including the target itself, its used as container-serve.

```Makefile
container-targets: container-image container-gen-content container-render container-server
```

```Makefile
docker-server:
	@echo -e "**** The use of docker-render is deprecated. Use container-serve instead. ****" 1>&2
	$(MAKE) container-serve

container-serve: ## Run Hugo locally within a container, available at http://localhost:1313/
```

Please let me know if we want to keep it container-serve (if the change was intentional) or container-server (consistent with outgoing docker-server).

thanks