### PR TITLE
Set sidebar menu to be compact by default

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -110,7 +110,7 @@ offlineSearch = false
 # User interface configuration
 [params.ui]
 # Enable to show the side bar menu in its compact state.
-sidebar_menu_compact = false
+sidebar_menu_compact = true
 #  Set to true to disable breadcrumb navigation.
 breadcrumb_disable = false
 #  Set to true to hide the sidebar search box (the top nav search box will still be displayed if search is enabled)


### PR DESCRIPTION
As we start to add more content, the menus on the side are getting quite busy. This flips them to be compact by default.